### PR TITLE
Fix Animated Circles

### DIFF
--- a/src/internal/convert.ts
+++ b/src/internal/convert.ts
@@ -16,14 +16,17 @@ const convert = async (
     let image = isVideo ? await videoToGif(data) : data
     const isAnimated = isVideo || mime.includes('gif')
 
-    if (isAnimated && [StickerTypes.CROPPED, StickerTypes.CIRCLE].includes(type)) {
+    if (isAnimated && ['crop', 'circle'].includes(type)) {
         const filename = `${tmpdir()}/${Math.random().toString(36)}.webp`
         await writeFile(filename, image)
-        ;[image, type] = [await crop(filename), type === StickerTypes.CIRCLE ? StickerTypes.CIRCLE : StickerTypes.DEFAULT]
+        ;[image, type] = [
+            await crop(filename),
+            type === StickerTypes.CIRCLE ? StickerTypes.CIRCLE : StickerTypes.DEFAULT
+        ]
     }
 
     const img = sharp(image, { animated: isAnimated }).toFormat('webp')
-    
+
     switch (type) {
         case StickerTypes.CROPPED:
             img.resize(512, 512, {
@@ -43,14 +46,12 @@ const convert = async (
                 fit: fit.cover
             }).composite([
                 {
-                    input: Buffer.from(
-                        `<svg><circle cx="256" cy="256" r="256" fill="${background}"/></svg>`
-                    ),
+                    input: Buffer.from(`<svg><circle cx="256" cy="256" r="256" fill="${background}"/></svg>`),
                     blend: 'dest-in',
                     gravity: 'northeast',
                     tile: true
                 }
-            ])            
+            ])
             break
     }
 

--- a/src/internal/convert.ts
+++ b/src/internal/convert.ts
@@ -41,9 +41,11 @@ const convert = async (
         }).composite([
             {
                 input: Buffer.from(
-                    `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512"><circle cx="256" cy="256" r="256" fill="${background}"/></svg>`
+                    `<svg><circle cx="256" cy="256" r="256" fill="${background}"/></svg>`
                 ),
-                blend: 'dest-in'
+                blend: 'dest-in',
+                gravity: 'northeast',
+                tile: true
             }
         ])
     }


### PR DESCRIPTION
I wish I could add more information about why "northeast" and "tile" are required, but without them, you can't circle-crop an animated webp. Also simplified the mask SVG.